### PR TITLE
Correção ao programa centrador e controlo de tapete por impulso em botão

### DIFF
--- a/Pentaplast_centrador_paletes_V16/S71200/PLC tags/Default tag table.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/PLC tags/Default tag table.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T16:07:52.668484Z</Created>
+    <Created>2022-12-12T11:32:02.2289348Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -839,7 +839,7 @@
           <ExternalVisible>true</ExternalVisible>
           <ExternalWritable>true</ExternalWritable>
           <LogicalAddress>%I4.2</LogicalAddress>
-          <Name>E4.2</Name>
+          <Name>Botão_iniciar_primeiro_tapete</Name>
         </AttributeList>
         <ObjectList>
           <MultilingualText ID="72" CompositionName="Comment">
@@ -853,7 +853,7 @@
               <MultilingualTextItem ID="74" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>POSIZIONAMENTO PALLET TRASPORTO POS. 01</Text>
+                  <Text />
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -2463,7 +2463,7 @@
           <ExternalVisible>true</ExternalVisible>
           <ExternalWritable>true</ExternalWritable>
           <LogicalAddress>%Q4.1</LogicalAddress>
-          <Name>A4.1</Name>
+          <Name>Motor_Tapete_Centrador</Name>
         </AttributeList>
         <ObjectList>
           <MultilingualText ID="15A" CompositionName="Comment">
@@ -2687,7 +2687,7 @@
           <ExternalVisible>true</ExternalVisible>
           <ExternalWritable>true</ExternalWritable>
           <LogicalAddress>%Q5.1</LogicalAddress>
-          <Name>Motor_Tapete_Centrador</Name>
+          <Name>A5.1</Name>
         </AttributeList>
         <ObjectList>
           <MultilingualText ID="17A" CompositionName="Comment">
@@ -18715,6 +18715,62 @@
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="A6C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcTag>
+      <SW.Tags.PlcTag ID="A6D" CompositionName="Tags">
+        <AttributeList>
+          <DataTypeName>Bool</DataTypeName>
+          <ExternalAccessible>true</ExternalAccessible>
+          <ExternalVisible>true</ExternalVisible>
+          <ExternalWritable>true</ExternalWritable>
+          <LogicalAddress>%M300.0</LogicalAddress>
+          <Name>Tag_2</Name>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="A6E" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="A6F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="A70" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Tags.PlcTag>
+      <SW.Tags.PlcTag ID="A71" CompositionName="Tags">
+        <AttributeList>
+          <DataTypeName>Bool</DataTypeName>
+          <ExternalAccessible>true</ExternalAccessible>
+          <ExternalVisible>true</ExternalVisible>
+          <ExternalWritable>true</ExternalWritable>
+          <LogicalAddress>%M300.1</LogicalAddress>
+          <Name>Tag_3</Name>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="A72" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="A73" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="A74" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Centrador_Paletes.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Centrador_Paletes.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T14:13:09.8866891Z</Created>
+    <Created>2022-12-12T13:48:36.0347787Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -43,7 +43,7 @@
       </Product>
     </InstalledProducts>
   </DocumentInfo>
-  <SW.Blocks.FC ID="0">
+  <SW.Blocks.FB ID="0">
     <AttributeList>
       <AutoNumber>true</AutoNumber>
       <HeaderAuthor />
@@ -51,24 +51,33 @@
       <HeaderName />
       <HeaderVersion>0.1</HeaderVersion>
       <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v4">
-  <Section Name="Input" />
-  <Section Name="Output" />
+  <Section Name="Input">
+    <Member Name="Centrador_Aberto_1" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Centrador_Aberto_2" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Detetor_Palete" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Palete_Centrada_1" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Palete_Centrada_2" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+  </Section>
+  <Section Name="Output">
+    <Member Name="ETAPA 1 (INICIO)" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList><StartValue>true</StartValue></Member>
+    <Member Name="ETAPA 2" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="ETAPA 3" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="ETAPA 4" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Tapete_Centrador" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Centrador_Sentido_Direto" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Centrador_Sentido_Inverso" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+  </Section>
   <Section Name="InOut" />
-  <Section Name="Temp">
-    <Member Name="ETAPA 1 (INICIO)" Datatype="Bool" />
-    <Member Name="ETAPA 2" Datatype="Bool" />
-    <Member Name="ETAPA 3" Datatype="Bool" />
-    <Member Name="ETAPA 4" Datatype="Bool" />
-  </Section>
+  <Section Name="Static" />
+  <Section Name="Temp" />
   <Section Name="Constant" />
-  <Section Name="Return">
-    <Member Name="Ret_Val" Datatype="Void" Accessibility="Public" />
-  </Section>
 </Sections></Interface>
       <IsIECCheckEnabled>false</IsIECCheckEnabled>
+      <IsRetainMemResEnabled>false</IsRetainMemResEnabled>
       <MemoryLayout>Optimized</MemoryLayout>
+      <MemoryReserve>100</MemoryReserve>
       <Name>Centrador_Paletes</Name>
-      <Number>17</Number>
+      <Number>2</Number>
       <ProgrammingLanguage>LAD</ProgrammingLanguage>
       <SetENOAutomatically>false</SetENOAutomatically>
       <UDABlockProperties />
@@ -95,68 +104,115 @@
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="FirstScan" />
-      </Symbol>
-    </Access>
-    <Access Scope="LocalVariable" UId="22">
+    <Access Scope="LocalVariable" UId="21">
       <Symbol>
         <Component Name="ETAPA 1 (INICIO)" />
       </Symbol>
     </Access>
-    <Access Scope="LocalVariable" UId="23">
-      <Symbol>
-        <Component Name="ETAPA 2" />
-      </Symbol>
-    </Access>
-    <Access Scope="LocalVariable" UId="24">
-      <Symbol>
-        <Component Name="ETAPA 3" />
-      </Symbol>
-    </Access>
-    <Access Scope="LocalVariable" UId="25">
+    <Access Scope="LocalVariable" UId="22">
       <Symbol>
         <Component Name="ETAPA 4" />
       </Symbol>
     </Access>
-    <Part Name="Contact" UId="26" />
-    <Part Name="SCoil" UId="27" />
-    <Part Name="RCoil" UId="28" />
-    <Part Name="RCoil" UId="29" />
-    <Part Name="RCoil" UId="30" />
+    <Access Scope="LocalVariable" UId="23">
+      <Symbol>
+        <Component Name="Centrador_Aberto_1" />
+      </Symbol>
+    </Access>
+    <Access Scope="LocalVariable" UId="24">
+      <Symbol>
+        <Component Name="Centrador_Aberto_2" />
+      </Symbol>
+    </Access>
+    <Access Scope="LocalVariable" UId="25">
+      <Symbol>
+        <Component Name="ETAPA 2" />
+      </Symbol>
+    </Access>
+    <Access Scope="LocalVariable" UId="26">
+      <Symbol>
+        <Component Name="ETAPA 1 (INICIO)" />
+      </Symbol>
+    </Access>
+    <Access Scope="LocalVariable" UId="27">
+      <Symbol>
+        <Component Name="ETAPA 4" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="28" />
+    <Part Name="Contact" UId="29" />
+    <Part Name="O" UId="30">
+      <TemplateValue Name="Card" Type="Cardinality">2</TemplateValue>
+    </Part>
+    <Part Name="Contact" UId="31" />
+    <Part Name="Contact" UId="32" />
+    <Part Name="O" UId="33">
+      <TemplateValue Name="Card" Type="Cardinality">2</TemplateValue>
+    </Part>
+    <Part Name="SCoil" UId="34" />
+    <Part Name="RCoil" UId="35" />
+    <Part Name="RCoil" UId="36" />
   </Parts>
   <Wires>
-    <Wire UId="31">
+    <Wire UId="37">
       <Powerrail />
-      <NameCon UId="26" Name="in" />
-    </Wire>
-    <Wire UId="32">
-      <IdentCon UId="21" />
-      <NameCon UId="26" Name="operand" />
-    </Wire>
-    <Wire UId="33">
-      <NameCon UId="26" Name="out" />
-      <NameCon UId="27" Name="in" />
       <NameCon UId="28" Name="in" />
       <NameCon UId="29" Name="in" />
-      <NameCon UId="30" Name="in" />
     </Wire>
-    <Wire UId="34">
-      <IdentCon UId="22" />
-      <NameCon UId="27" Name="operand" />
-    </Wire>
-    <Wire UId="35">
-      <IdentCon UId="23" />
+    <Wire UId="38">
+      <IdentCon UId="21" />
       <NameCon UId="28" Name="operand" />
     </Wire>
-    <Wire UId="36">
-      <IdentCon UId="24" />
+    <Wire UId="39">
+      <NameCon UId="28" Name="out" />
+      <NameCon UId="30" Name="in1" />
+    </Wire>
+    <Wire UId="40">
+      <IdentCon UId="22" />
       <NameCon UId="29" Name="operand" />
     </Wire>
-    <Wire UId="37">
+    <Wire UId="41">
+      <NameCon UId="29" Name="out" />
+      <NameCon UId="30" Name="in2" />
+    </Wire>
+    <Wire UId="42">
+      <NameCon UId="30" Name="out" />
+      <NameCon UId="31" Name="in" />
+      <NameCon UId="32" Name="in" />
+    </Wire>
+    <Wire UId="43">
+      <IdentCon UId="23" />
+      <NameCon UId="31" Name="operand" />
+    </Wire>
+    <Wire UId="44">
+      <NameCon UId="31" Name="out" />
+      <NameCon UId="33" Name="in1" />
+    </Wire>
+    <Wire UId="45">
+      <IdentCon UId="24" />
+      <NameCon UId="32" Name="operand" />
+    </Wire>
+    <Wire UId="46">
+      <NameCon UId="32" Name="out" />
+      <NameCon UId="33" Name="in2" />
+    </Wire>
+    <Wire UId="47">
+      <NameCon UId="33" Name="out" />
+      <NameCon UId="34" Name="in" />
+      <NameCon UId="35" Name="in" />
+      <NameCon UId="36" Name="in" />
+    </Wire>
+    <Wire UId="48">
       <IdentCon UId="25" />
-      <NameCon UId="30" Name="operand" />
+      <NameCon UId="34" Name="operand" />
+    </Wire>
+    <Wire UId="49">
+      <IdentCon UId="26" />
+      <NameCon UId="35" Name="operand" />
+    </Wire>
+    <Wire UId="50">
+      <IdentCon UId="27" />
+      <NameCon UId="36" Name="operand" />
     </Wire>
   </Wires>
 </FlgNet></NetworkSource>
@@ -184,7 +240,7 @@
               <MultilingualTextItem ID="9" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
-                  <Text>ETAPA 1 (INICIO)</Text>
+                  <Text>ETAPA 2 - Arranque de tapete do centrador</Text>
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="A" CompositionName="Items">
@@ -203,22 +259,22 @@
   <Parts>
     <Access Scope="LocalVariable" UId="21">
       <Symbol>
-        <Component Name="ETAPA 1 (INICIO)" />
+        <Component Name="ETAPA 2" />
       </Symbol>
     </Access>
     <Access Scope="LocalVariable" UId="22">
       <Symbol>
-        <Component Name="ETAPA 4" />
+        <Component Name="Detetor_Palete" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="23">
       <Symbol>
-        <Component Name="Centrador_Aberto_1" />
+        <Component Name="M13.0" />
       </Symbol>
     </Access>
-    <Access Scope="GlobalVariable" UId="24">
+    <Access Scope="LocalVariable" UId="24">
       <Symbol>
-        <Component Name="Centrador_Aberto_2" />
+        <Component Name="ETAPA 3" />
       </Symbol>
     </Access>
     <Access Scope="LocalVariable" UId="25">
@@ -226,82 +282,44 @@
         <Component Name="ETAPA 2" />
       </Symbol>
     </Access>
-    <Access Scope="LocalVariable" UId="26">
-      <Symbol>
-        <Component Name="ETAPA 1 (INICIO)" />
-      </Symbol>
-    </Access>
-    <Access Scope="LocalVariable" UId="27">
-      <Symbol>
-        <Component Name="ETAPA 4" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="28" />
-    <Part Name="Contact" UId="29" />
-    <Part Name="O" UId="30">
-      <TemplateValue Name="Card" Type="Cardinality">2</TemplateValue>
-    </Part>
-    <Part Name="Contact" UId="31" />
-    <Part Name="Contact" UId="32" />
-    <Part Name="SCoil" UId="33" />
-    <Part Name="RCoil" UId="34" />
-    <Part Name="RCoil" UId="35" />
+    <Part Name="Contact" UId="26" />
+    <Part Name="PContact" UId="27" />
+    <Part Name="SCoil" UId="28" />
+    <Part Name="RCoil" UId="29" />
   </Parts>
   <Wires>
-    <Wire UId="36">
+    <Wire UId="30">
       <Powerrail />
+      <NameCon UId="26" Name="in" />
+    </Wire>
+    <Wire UId="31">
+      <IdentCon UId="21" />
+      <NameCon UId="26" Name="operand" />
+    </Wire>
+    <Wire UId="32">
+      <NameCon UId="26" Name="out" />
+      <NameCon UId="27" Name="pre" />
+    </Wire>
+    <Wire UId="33">
+      <IdentCon UId="23" />
+      <NameCon UId="27" Name="bit" />
+    </Wire>
+    <Wire UId="34">
+      <IdentCon UId="22" />
+      <NameCon UId="27" Name="operand" />
+    </Wire>
+    <Wire UId="35">
+      <NameCon UId="27" Name="out" />
       <NameCon UId="28" Name="in" />
       <NameCon UId="29" Name="in" />
     </Wire>
-    <Wire UId="37">
-      <IdentCon UId="21" />
+    <Wire UId="36">
+      <IdentCon UId="24" />
       <NameCon UId="28" Name="operand" />
     </Wire>
-    <Wire UId="38">
-      <NameCon UId="28" Name="out" />
-      <NameCon UId="30" Name="in1" />
-    </Wire>
-    <Wire UId="39">
-      <IdentCon UId="22" />
-      <NameCon UId="29" Name="operand" />
-    </Wire>
-    <Wire UId="40">
-      <NameCon UId="29" Name="out" />
-      <NameCon UId="30" Name="in2" />
-    </Wire>
-    <Wire UId="41">
-      <NameCon UId="30" Name="out" />
-      <NameCon UId="31" Name="in" />
-    </Wire>
-    <Wire UId="42">
-      <IdentCon UId="23" />
-      <NameCon UId="31" Name="operand" />
-    </Wire>
-    <Wire UId="43">
-      <NameCon UId="31" Name="out" />
-      <NameCon UId="32" Name="in" />
-    </Wire>
-    <Wire UId="44">
-      <IdentCon UId="24" />
-      <NameCon UId="32" Name="operand" />
-    </Wire>
-    <Wire UId="45">
-      <NameCon UId="32" Name="out" />
-      <NameCon UId="33" Name="in" />
-      <NameCon UId="34" Name="in" />
-      <NameCon UId="35" Name="in" />
-    </Wire>
-    <Wire UId="46">
+    <Wire UId="37">
       <IdentCon UId="25" />
-      <NameCon UId="33" Name="operand" />
-    </Wire>
-    <Wire UId="47">
-      <IdentCon UId="26" />
-      <NameCon UId="34" Name="operand" />
-    </Wire>
-    <Wire UId="48">
-      <IdentCon UId="27" />
-      <NameCon UId="35" Name="operand" />
+      <NameCon UId="29" Name="operand" />
     </Wire>
   </Wires>
 </FlgNet></NetworkSource>
@@ -329,7 +347,7 @@
               <MultilingualTextItem ID="10" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
-                  <Text>ETAPA 2</Text>
+                  <Text>ETAPA 3 - Centragem da palete</Text>
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="11" CompositionName="Items">
@@ -348,113 +366,15 @@
   <Parts>
     <Access Scope="LocalVariable" UId="21">
       <Symbol>
-        <Component Name="ETAPA 2" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="E3.2" />
-      </Symbol>
-    </Access>
-    <Access Scope="LocalVariable" UId="23">
-      <Symbol>
         <Component Name="ETAPA 3" />
       </Symbol>
     </Access>
-    <Access Scope="LocalVariable" UId="24">
-      <Symbol>
-        <Component Name="ETAPA 2" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="25" />
-    <Part Name="Contact" UId="26" />
-    <Part Name="SCoil" UId="27" />
-    <Part Name="RCoil" UId="28" />
-  </Parts>
-  <Wires>
-    <Wire UId="29">
-      <Powerrail />
-      <NameCon UId="25" Name="in" />
-    </Wire>
-    <Wire UId="30">
-      <IdentCon UId="21" />
-      <NameCon UId="25" Name="operand" />
-    </Wire>
-    <Wire UId="31">
-      <NameCon UId="25" Name="out" />
-      <NameCon UId="26" Name="in" />
-    </Wire>
-    <Wire UId="32">
-      <IdentCon UId="22" />
-      <NameCon UId="26" Name="operand" />
-    </Wire>
-    <Wire UId="33">
-      <NameCon UId="26" Name="out" />
-      <NameCon UId="27" Name="in" />
-      <NameCon UId="28" Name="in" />
-    </Wire>
-    <Wire UId="34">
-      <IdentCon UId="23" />
-      <NameCon UId="27" Name="operand" />
-    </Wire>
-    <Wire UId="35">
-      <IdentCon UId="24" />
-      <NameCon UId="28" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
-        <ObjectList>
-          <MultilingualText ID="13" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="14" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="15" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="16" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="17" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text>ETAPA 3</Text>
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="18" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="19" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="LocalVariable" UId="21">
-      <Symbol>
-        <Component Name="ETAPA 3" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
+    <Access Scope="LocalVariable" UId="22">
       <Symbol>
         <Component Name="Palete_Centrada_1" />
       </Symbol>
     </Access>
-    <Access Scope="GlobalVariable" UId="23">
+    <Access Scope="LocalVariable" UId="23">
       <Symbol>
         <Component Name="Palete_Centrada_2" />
       </Symbol>
@@ -518,6 +438,94 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
+          <MultilingualText ID="13" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="14" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="15" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="16" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="17" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>ETAPA 4 - Retoma centrador à posição inicial (aberto)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="18" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="19" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="LocalVariable" UId="21">
+      <Symbol>
+        <Component Name="ETAPA 2" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="DB10_ExtConveyors" />
+        <Component Name="Out_ConvPos2" />
+      </Symbol>
+    </Access>
+    <Access Scope="LocalVariable" UId="23">
+      <Symbol>
+        <Component Name="Motor_Tapete_Centrador" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="24" />
+    <Part Name="Contact" UId="25" />
+    <Part Name="Coil" UId="26" />
+  </Parts>
+  <Wires>
+    <Wire UId="27">
+      <Powerrail />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="21" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+    <Wire UId="29">
+      <NameCon UId="24" Name="out" />
+      <NameCon UId="25" Name="in" />
+    </Wire>
+    <Wire UId="30">
+      <IdentCon UId="22" />
+      <NameCon UId="25" Name="operand" />
+    </Wire>
+    <Wire UId="31">
+      <NameCon UId="25" Name="out" />
+      <NameCon UId="26" Name="in" />
+    </Wire>
+    <Wire UId="32">
+      <IdentCon UId="23" />
+      <NameCon UId="26" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
           <MultilingualText ID="1A" CompositionName="Comment">
             <ObjectList>
               <MultilingualTextItem ID="1B" CompositionName="Items">
@@ -539,7 +547,7 @@
               <MultilingualTextItem ID="1E" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
-                  <Text>ETAPA 4</Text>
+                  <Text>COMANDO MOTOR TAPETE</Text>
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="1F" CompositionName="Items">
@@ -558,12 +566,12 @@
   <Parts>
     <Access Scope="LocalVariable" UId="21">
       <Symbol>
-        <Component Name="ETAPA 2" />
+        <Component Name="ETAPA 3" />
       </Symbol>
     </Access>
-    <Access Scope="GlobalVariable" UId="22">
+    <Access Scope="LocalVariable" UId="22">
       <Symbol>
-        <Component Name="Motor_Tapete_Centrador" />
+        <Component Name="Motor_Centrador_Sentido_Direto" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -612,7 +620,7 @@
               <MultilingualTextItem ID="25" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
-                  <Text>COMANDO MOTOR TAPETE</Text>
+                  <Text>MOTOR CENTRADOR SENTIDO DIRETO</Text>
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="26" CompositionName="Items">
@@ -631,12 +639,12 @@
   <Parts>
     <Access Scope="LocalVariable" UId="21">
       <Symbol>
-        <Component Name="ETAPA 3" />
+        <Component Name="ETAPA 4" />
       </Symbol>
     </Access>
-    <Access Scope="GlobalVariable" UId="22">
+    <Access Scope="LocalVariable" UId="22">
       <Symbol>
-        <Component Name="Motor_Centrador_Sentido_Direto" />
+        <Component Name="Motor_Centrador_Sentido_Inverso" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -685,7 +693,7 @@
               <MultilingualTextItem ID="2C" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
-                  <Text>MOTOR CENTRADOR SENTIDO DIRETO</Text>
+                  <Text>MOTOR CENTRADOR SENTIDO INVERSO</Text>
                 </AttributeList>
               </MultilingualTextItem>
               <MultilingualTextItem ID="2D" CompositionName="Items">
@@ -698,128 +706,15 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="2E" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="LocalVariable" UId="21">
-      <Symbol>
-        <Component Name="ETAPA 4" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="Motor_Centrador_Sentido_Inverso" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
+      <MultilingualText ID="2E" CompositionName="Title">
         <ObjectList>
-          <MultilingualText ID="2F" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="30" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="31" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="32" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="33" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text>MOTOR CENTRADOR SENTIDO INVERSO</Text>
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="34" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="35" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource />
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
-        <ObjectList>
-          <MultilingualText ID="36" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="37" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="38" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="39" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="3A" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="3B" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <MultilingualText ID="3C" CompositionName="Title">
-        <ObjectList>
-          <MultilingualTextItem ID="3D" CompositionName="Items">
+          <MultilingualTextItem ID="2F" CompositionName="Items">
             <AttributeList>
               <Culture>en-US</Culture>
               <Text>CONTROLO DE CENTRADOR DE PALETES</Text>
             </AttributeList>
           </MultilingualTextItem>
-          <MultilingualTextItem ID="3E" CompositionName="Items">
+          <MultilingualTextItem ID="30" CompositionName="Items">
             <AttributeList>
               <Culture>it-IT</Culture>
               <Text />
@@ -828,5 +723,5 @@
         </ObjectList>
       </MultilingualText>
     </ObjectList>
-  </SW.Blocks.FC>
+  </SW.Blocks.FB>
 </Document>

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Centrador_Paletes_DB.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Centrador_Paletes_DB.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V16" />
+  <DocumentInfo>
+    <Created>2022-12-12T13:38:05.5321597Z</Created>
+    <ExportSetting>WithDefaults</ExportSetting>
+    <InstalledProducts>
+      <Product>
+        <DisplayName>Totally Integrated Automation Portal</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>TIA Portal Version Control Interface</DisplayName>
+        <DisplayVersion>V16 Update 2</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>TIA Portal Openness</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>SINAMICS Startdrive Advanced</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G130, G150, S120, S150, SINAMICS MV, S210</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G110M, G120, G120C, G120D, G120P, G115D</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>STEP 7 Professional</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>STEP 7 Safety</DisplayName>
+        <DisplayVersion>V16</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>WinCC Advanced</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+    </InstalledProducts>
+  </DocumentInfo>
+  <SW.Blocks.InstanceDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <HeaderAuthor />
+      <HeaderFamily />
+      <HeaderName />
+      <HeaderVersion>0.1</HeaderVersion>
+      <InstanceOfName>Centrador_Paletes</InstanceOfName>
+      <InstanceOfType>FB</InstanceOfType>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v4">
+  <Section Name="Input">
+    <Member Name="Centrador_Aberto_1" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Centrador_Aberto_2" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Detetor_Palete" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Palete_Centrada_1" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Palete_Centrada_2" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+  </Section>
+  <Section Name="Output">
+    <Member Name="ETAPA 1 (INICIO)" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="ETAPA 2" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="ETAPA 3" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="ETAPA 4" Datatype="Bool" Remanence="Retain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Tapete_Centrador" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Centrador_Sentido_Direto" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+    <Member Name="Motor_Centrador_Sentido_Inverso" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute></AttributeList></Member>
+  </Section>
+  <Section Name="InOut" />
+  <Section Name="Static" />
+</Sections></Interface>
+      <Name>Centrador_Paletes_DB</Name>
+      <Number>11</Number>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+    <ObjectList>
+      <MultilingualText ID="1" CompositionName="Comment">
+        <ObjectList>
+          <MultilingualTextItem ID="2" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="3" CompositionName="Items">
+            <AttributeList>
+              <Culture>it-IT</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+      <MultilingualText ID="4" CompositionName="Title">
+        <ObjectList>
+          <MultilingualTextItem ID="5" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="6" CompositionName="Items">
+            <AttributeList>
+              <Culture>it-IT</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+    </ObjectList>
+  </SW.Blocks.InstanceDB>
+</Document>

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC00_SupportIn.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC00_SupportIn.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T15:20:40.905747Z</Created>
+    <Created>2022-12-12T11:14:07.5975361Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -4630,7 +4630,7 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="E4.2" />
+        <Component Name="Botão_iniciar_primeiro_tapete" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC01_SupportOut.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC01_SupportOut.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T15:20:41.6466211Z</Created>
+    <Created>2022-12-12T11:46:17.7729577Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -3087,12 +3087,13 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos2" />
+        <Component Name="Out_ConvPos2X2" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.1" />
+        <Component Name="DB10_ExtConveyors" />
+        <Component Name="Out_ConvPos2X2" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3147,7 +3148,7 @@
               <MultilingualTextItem ID="145" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos2 motor</Text>
+                  <Text>Conveyor pos2 motor speed selection X2</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3161,13 +3162,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos2X2" />
+        <Component Name="Out_ConvPos3" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos2X2" />
+        <Component Name="A4.2" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3222,7 +3222,7 @@
               <MultilingualTextItem ID="14C" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos2 motor speed selection X2</Text>
+                  <Text>Conveyor pos3 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3236,12 +3236,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos3" />
+        <Component Name="Out_ConvPos4" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.2" />
+        <Component Name="A4.3" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3296,7 +3296,7 @@
               <MultilingualTextItem ID="153" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos3 motor</Text>
+                  <Text>Conveyor pos4 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3310,12 +3310,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos4" />
+        <Component Name="Out_ConvPos5" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.3" />
+        <Component Name="A4.4" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3370,7 +3370,7 @@
               <MultilingualTextItem ID="15A" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos4 motor</Text>
+                  <Text>Conveyor pos5 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3384,12 +3384,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos5" />
+        <Component Name="Out_ConvPos6" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.4" />
+        <Component Name="A4.5" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3444,7 +3444,7 @@
               <MultilingualTextItem ID="161" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos5 motor</Text>
+                  <Text>Conveyor pos6 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3458,12 +3458,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos6" />
+        <Component Name="Out_ConvPos7" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.5" />
+        <Component Name="A4.6" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3518,7 +3518,7 @@
               <MultilingualTextItem ID="168" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos6 motor</Text>
+                  <Text>Conveyor pos7 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3532,12 +3532,12 @@
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
         <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos7" />
+        <Component Name="Out_ConvPos8" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A4.6" />
+        <Component Name="A4.7" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -3592,7 +3592,7 @@
               <MultilingualTextItem ID="16F" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos7 motor</Text>
+                  <Text>Conveyor pos8 motor</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -3601,41 +3601,7 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="170" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="DB10_ExtConveyors" />
-        <Component Name="Out_ConvPos8" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="A4.7" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
+          <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -3666,46 +3632,6 @@
               <MultilingualTextItem ID="176" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Conveyor pos8 motor</Text>
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="177" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource />
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
-        <ObjectList>
-          <MultilingualText ID="178" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="179" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="17A" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="17B" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="17C" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="17D" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
                   <Text>***TOP***</Text>
                 </AttributeList>
               </MultilingualTextItem>
@@ -3713,7 +3639,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="17E" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="177" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -3752,15 +3678,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="17F" CompositionName="Comment">
+          <MultilingualText ID="178" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="180" CompositionName="Items">
+              <MultilingualTextItem ID="179" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="181" CompositionName="Items">
+              <MultilingualTextItem ID="17A" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -3768,15 +3694,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="182" CompositionName="Title">
+          <MultilingualText ID="17B" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="183" CompositionName="Items">
+              <MultilingualTextItem ID="17C" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="184" CompositionName="Items">
+              <MultilingualTextItem ID="17D" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Top carriage forward (Top)</Text>
@@ -3786,7 +3712,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="185" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="17E" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -3841,15 +3767,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="186" CompositionName="Comment">
+          <MultilingualText ID="17F" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="187" CompositionName="Items">
+              <MultilingualTextItem ID="180" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="188" CompositionName="Items">
+              <MultilingualTextItem ID="181" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -3857,15 +3783,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="189" CompositionName="Title">
+          <MultilingualText ID="182" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="18A" CompositionName="Items">
+              <MultilingualTextItem ID="183" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="18B" CompositionName="Items">
+              <MultilingualTextItem ID="184" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Top carriage backward (Top)</Text>
@@ -3875,7 +3801,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="18C" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="185" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -3914,15 +3840,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="18D" CompositionName="Comment">
+          <MultilingualText ID="186" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="18E" CompositionName="Items">
+              <MultilingualTextItem ID="187" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="18F" CompositionName="Items">
+              <MultilingualTextItem ID="188" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -3930,15 +3856,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="190" CompositionName="Title">
+          <MultilingualText ID="189" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="191" CompositionName="Items">
+              <MultilingualTextItem ID="18A" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="192" CompositionName="Items">
+              <MultilingualTextItem ID="18B" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Top carriage upward (Top)</Text>
@@ -3948,7 +3874,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="193" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="18C" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4003,6 +3929,79 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
+          <MultilingualText ID="18D" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="18E" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="18F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="190" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="191" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="192" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text>Top carriage downward (Top)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="193" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="A85" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="A6.4" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="Coil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
           <MultilingualText ID="194" CompositionName="Comment">
             <ObjectList>
               <MultilingualTextItem ID="195" CompositionName="Items">
@@ -4030,7 +4029,7 @@
               <MultilingualTextItem ID="199" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Top carriage downward (Top)</Text>
+                  <Text>Top carriage brake (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4043,12 +4042,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A85" />
+        <Component Name="A82" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A6.4" />
+        <Component Name="A6.5" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4103,7 +4102,7 @@
               <MultilingualTextItem ID="1A0" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Top carriage brake (Top)</Text>
+                  <Text>Opening clamp to block top film (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4116,12 +4115,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A82" />
+        <Component Name="A81" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A6.5" />
+        <Component Name="A6.6" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4176,79 +4175,6 @@
               <MultilingualTextItem ID="1A7" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Opening clamp to block top film (Top)</Text>
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="1A8" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="A81" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="A6.6" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
-        <ObjectList>
-          <MultilingualText ID="1A9" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="1AA" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="1AB" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="1AC" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="1AD" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="1AE" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
                   <Text>Closing clamp to block top film (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
@@ -4256,7 +4182,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="1AF" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="1A8" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4311,6 +4237,79 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
+          <MultilingualText ID="1A9" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="1AA" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="1AB" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="1AC" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="1AD" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="1AE" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text>Top cutter forward (Top)</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="1AF" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="A80" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="A7.0" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="Coil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
           <MultilingualText ID="1B0" CompositionName="Comment">
             <ObjectList>
               <MultilingualTextItem ID="1B1" CompositionName="Items">
@@ -4338,7 +4337,7 @@
               <MultilingualTextItem ID="1B5" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Top cutter forward (Top)</Text>
+                  <Text>Top cutter backward (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4351,12 +4350,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A80" />
+        <Component Name="A84" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A7.0" />
+        <Component Name="A7.1" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4411,7 +4410,7 @@
               <MultilingualTextItem ID="1BC" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Top cutter backward (Top)</Text>
+                  <Text>Opening clamp to lift(pull) top film (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4424,12 +4423,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A84" />
+        <Component Name="A83" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A7.1" />
+        <Component Name="A7.2" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4484,7 +4483,7 @@
               <MultilingualTextItem ID="1C3" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Opening clamp to lift(pull) top film (Top)</Text>
+                  <Text>Closing clamp to lift(pull) top film (Top)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4493,40 +4492,7 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="1C4" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="A83" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="A7.2" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
+          <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -4557,7 +4523,7 @@
               <MultilingualTextItem ID="1CA" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Closing clamp to lift(pull) top film (Top)</Text>
+                  <Text>OTHER</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4566,7 +4532,40 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="1CB" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource />
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="A32" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="A32" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="Coil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -4597,7 +4596,7 @@
               <MultilingualTextItem ID="1D1" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>OTHER</Text>
+                  <Text>Ready to receive pallet from infeed signal reverse cycle</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4610,12 +4609,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A32" />
+        <Component Name="A33" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A32" />
+        <Component Name="A33" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4670,7 +4669,7 @@
               <MultilingualTextItem ID="1D8" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Ready to receive pallet from infeed signal reverse cycle</Text>
+                  <Text>End of pallet transfer from infeed signal reverse cycle</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4679,40 +4678,7 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="1D9" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="A33" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="A33" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
+          <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -4743,7 +4709,7 @@
               <MultilingualTextItem ID="1DF" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>End of pallet transfer from infeed signal reverse cycle</Text>
+                  <Text>OLD (NOT USED)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4752,7 +4718,40 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="1E0" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource />
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="A08_NotUsed" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="A08_NotUsed" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="Coil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -4783,7 +4782,7 @@
               <MultilingualTextItem ID="1E6" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>OLD (NOT USED)</Text>
+                  <Text>Speed selection (X2-S4I) on arm rotation inverter (Technoplat)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4796,12 +4795,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A08_NotUsed" />
+        <Component Name="A09_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A08_NotUsed" />
+        <Component Name="A09_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4856,7 +4855,7 @@
               <MultilingualTextItem ID="1ED" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Speed selection (X2-S4I) on arm rotation inverter (Technoplat)</Text>
+                  <Text>Speed selection (X3-S5I) on arm rotation inverter (Technoplat)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4869,12 +4868,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A09_NotUsed" />
+        <Component Name="A17_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A09_NotUsed" />
+        <Component Name="A17_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -4929,7 +4928,7 @@
               <MultilingualTextItem ID="1F4" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Speed selection (X3-S5I) on arm rotation inverter (Technoplat)</Text>
+                  <Text>Pallet lifter upward(1)/downard (Lifter)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -4942,12 +4941,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A17_NotUsed" />
+        <Component Name="A27_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A17_NotUsed" />
+        <Component Name="A27_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -5002,7 +5001,7 @@
               <MultilingualTextItem ID="1FB" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Pallet lifter upward(1)/downard (Lifter)</Text>
+                  <Text>?</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -5015,12 +5014,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A27_NotUsed" />
+        <Component Name="A40_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A27_NotUsed" />
+        <Component Name="A40_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -5088,12 +5087,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A40_NotUsed" />
+        <Component Name="A45_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A40_NotUsed" />
+        <Component Name="A45_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -5148,7 +5147,7 @@
               <MultilingualTextItem ID="209" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>?</Text>
+                  <Text>Welder unit upward(1)/downward (RingSpring clamp)</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -5161,12 +5160,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A45_NotUsed" />
+        <Component Name="A53_NotUsed" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A45_NotUsed" />
+        <Component Name="A53_NotUsed" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -5221,7 +5220,7 @@
               <MultilingualTextItem ID="210" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>Welder unit upward(1)/downward (RingSpring clamp)</Text>
+                  <Text>??? Film clamp double closing (Claw clamp) ???</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -5234,12 +5233,12 @@
   <Parts>
     <Access Scope="GlobalVariable" UId="21">
       <Symbol>
-        <Component Name="A53_NotUsed" />
+        <Component Name="A28" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="22">
       <Symbol>
-        <Component Name="A53_NotUsed" />
+        <Component Name="A5.0" />
       </Symbol>
     </Access>
     <Part Name="Contact" UId="23" />
@@ -5294,7 +5293,7 @@
               <MultilingualTextItem ID="217" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>??? Film clamp double closing (Claw clamp) ???</Text>
+                  <Text>LedBypass</Text>
                 </AttributeList>
               </MultilingualTextItem>
             </ObjectList>
@@ -5303,40 +5302,7 @@
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="218" CompositionName="CompileUnits">
         <AttributeList>
-          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
-  <Parts>
-    <Access Scope="GlobalVariable" UId="21">
-      <Symbol>
-        <Component Name="A28" />
-      </Symbol>
-    </Access>
-    <Access Scope="GlobalVariable" UId="22">
-      <Symbol>
-        <Component Name="A5.0" />
-      </Symbol>
-    </Access>
-    <Part Name="Contact" UId="23" />
-    <Part Name="Coil" UId="24" />
-  </Parts>
-  <Wires>
-    <Wire UId="25">
-      <Powerrail />
-      <NameCon UId="23" Name="in" />
-    </Wire>
-    <Wire UId="26">
-      <IdentCon UId="21" />
-      <NameCon UId="23" Name="operand" />
-    </Wire>
-    <Wire UId="27">
-      <NameCon UId="23" Name="out" />
-      <NameCon UId="24" Name="in" />
-    </Wire>
-    <Wire UId="28">
-      <IdentCon UId="22" />
-      <NameCon UId="24" Name="operand" />
-    </Wire>
-  </Wires>
-</FlgNet></NetworkSource>
+          <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
@@ -5367,46 +5333,6 @@
               <MultilingualTextItem ID="21E" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
-                  <Text>LedBypass</Text>
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-        </ObjectList>
-      </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="21F" CompositionName="CompileUnits">
-        <AttributeList>
-          <NetworkSource />
-          <ProgrammingLanguage>LAD</ProgrammingLanguage>
-        </AttributeList>
-        <ObjectList>
-          <MultilingualText ID="220" CompositionName="Comment">
-            <ObjectList>
-              <MultilingualTextItem ID="221" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="222" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-            </ObjectList>
-          </MultilingualText>
-          <MultilingualText ID="223" CompositionName="Title">
-            <ObjectList>
-              <MultilingualTextItem ID="224" CompositionName="Items">
-                <AttributeList>
-                  <Culture>en-US</Culture>
-                  <Text />
-                </AttributeList>
-              </MultilingualTextItem>
-              <MultilingualTextItem ID="225" CompositionName="Items">
-                <AttributeList>
-                  <Culture>it-IT</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
@@ -5414,15 +5340,15 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <MultilingualText ID="226" CompositionName="Title">
+      <MultilingualText ID="21F" CompositionName="Title">
         <ObjectList>
-          <MultilingualTextItem ID="227" CompositionName="Items">
+          <MultilingualTextItem ID="220" CompositionName="Items">
             <AttributeList>
               <Culture>en-US</Culture>
               <Text />
             </AttributeList>
           </MultilingualTextItem>
-          <MultilingualTextItem ID="228" CompositionName="Items">
+          <MultilingualTextItem ID="221" CompositionName="Items">
             <AttributeList>
               <Culture>it-IT</Culture>
               <Text>Output support memory</Text>

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC86_Conveyor_5_IN_3_OUT.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/FC86_Conveyor_5_IN_3_OUT.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T15:20:58.7459882Z</Created>
+    <Created>2022-12-12T14:12:15.0004016Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -3336,100 +3336,99 @@
     </Access>
     <Access Scope="GlobalVariable" UId="33">
       <Symbol>
+        <Component Name="Tag_2" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="34">
+      <Symbol>
         <Component Name="DB10_ExtConveyors" />
         <Component Name="Out_ConvPos1" />
       </Symbol>
     </Access>
-    <Part Name="Contact" UId="34" />
     <Part Name="Contact" UId="35" />
     <Part Name="Contact" UId="36" />
     <Part Name="Contact" UId="37" />
     <Part Name="Contact" UId="38" />
     <Part Name="Contact" UId="39" />
     <Part Name="Contact" UId="40" />
-    <Part Name="Contact" UId="41">
-      <Negated Name="operand" />
-    </Part>
+    <Part Name="Contact" UId="41" />
     <Part Name="Contact" UId="42">
       <Negated Name="operand" />
     </Part>
     <Part Name="Contact" UId="43">
       <Negated Name="operand" />
     </Part>
-    <Part Name="Contact" UId="44" />
-    <Part Name="Contact" UId="45" />
-    <Part Name="O" UId="46">
-      <TemplateValue Name="Card" Type="Cardinality">5</TemplateValue>
+    <Part Name="Contact" UId="44">
+      <Negated Name="operand" />
     </Part>
-    <Part Name="Coil" UId="47" />
+    <Part Name="Contact" UId="45" />
+    <Part Name="Contact" UId="46" />
+    <Part Name="Contact" UId="47" />
+    <Part Name="O" UId="48">
+      <TemplateValue Name="Card" Type="Cardinality">6</TemplateValue>
+    </Part>
+    <Part Name="Coil" UId="49" />
   </Parts>
   <Wires>
-    <Wire UId="48">
-      <Powerrail />
-      <NameCon UId="34" Name="in" />
-      <NameCon UId="36" Name="in" />
-      <NameCon UId="40" Name="in" />
-      <NameCon UId="44" Name="in" />
-    </Wire>
-    <Wire UId="49">
-      <IdentCon UId="21" />
-      <NameCon UId="34" Name="operand" />
-    </Wire>
     <Wire UId="50">
-      <NameCon UId="34" Name="out" />
+      <Powerrail />
       <NameCon UId="35" Name="in" />
+      <NameCon UId="37" Name="in" />
+      <NameCon UId="41" Name="in" />
+      <NameCon UId="45" Name="in" />
+      <NameCon UId="47" Name="in" />
     </Wire>
     <Wire UId="51">
-      <IdentCon UId="22" />
+      <IdentCon UId="21" />
       <NameCon UId="35" Name="operand" />
     </Wire>
     <Wire UId="52">
       <NameCon UId="35" Name="out" />
-      <NameCon UId="46" Name="in1" />
+      <NameCon UId="36" Name="in" />
     </Wire>
     <Wire UId="53">
-      <IdentCon UId="23" />
+      <IdentCon UId="22" />
       <NameCon UId="36" Name="operand" />
     </Wire>
     <Wire UId="54">
       <NameCon UId="36" Name="out" />
-      <NameCon UId="37" Name="in" />
+      <NameCon UId="48" Name="in1" />
     </Wire>
     <Wire UId="55">
-      <IdentCon UId="24" />
+      <IdentCon UId="23" />
       <NameCon UId="37" Name="operand" />
     </Wire>
     <Wire UId="56">
       <NameCon UId="37" Name="out" />
       <NameCon UId="38" Name="in" />
-      <NameCon UId="39" Name="in" />
     </Wire>
     <Wire UId="57">
-      <IdentCon UId="25" />
+      <IdentCon UId="24" />
       <NameCon UId="38" Name="operand" />
     </Wire>
     <Wire UId="58">
       <NameCon UId="38" Name="out" />
-      <NameCon UId="46" Name="in2" />
+      <NameCon UId="39" Name="in" />
+      <NameCon UId="40" Name="in" />
     </Wire>
     <Wire UId="59">
-      <IdentCon UId="26" />
+      <IdentCon UId="25" />
       <NameCon UId="39" Name="operand" />
     </Wire>
     <Wire UId="60">
       <NameCon UId="39" Name="out" />
-      <NameCon UId="46" Name="in3" />
+      <NameCon UId="48" Name="in2" />
     </Wire>
     <Wire UId="61">
-      <IdentCon UId="27" />
+      <IdentCon UId="26" />
       <NameCon UId="40" Name="operand" />
     </Wire>
     <Wire UId="62">
       <NameCon UId="40" Name="out" />
-      <NameCon UId="41" Name="in" />
+      <NameCon UId="48" Name="in3" />
     </Wire>
     <Wire UId="63">
-      <IdentCon UId="28" />
+      <IdentCon UId="27" />
       <NameCon UId="41" Name="operand" />
     </Wire>
     <Wire UId="64">
@@ -3437,7 +3436,7 @@
       <NameCon UId="42" Name="in" />
     </Wire>
     <Wire UId="65">
-      <IdentCon UId="29" />
+      <IdentCon UId="28" />
       <NameCon UId="42" Name="operand" />
     </Wire>
     <Wire UId="66">
@@ -3445,36 +3444,52 @@
       <NameCon UId="43" Name="in" />
     </Wire>
     <Wire UId="67">
-      <IdentCon UId="30" />
+      <IdentCon UId="29" />
       <NameCon UId="43" Name="operand" />
     </Wire>
     <Wire UId="68">
       <NameCon UId="43" Name="out" />
-      <NameCon UId="46" Name="in4" />
+      <NameCon UId="44" Name="in" />
     </Wire>
     <Wire UId="69">
-      <IdentCon UId="31" />
+      <IdentCon UId="30" />
       <NameCon UId="44" Name="operand" />
     </Wire>
     <Wire UId="70">
       <NameCon UId="44" Name="out" />
-      <NameCon UId="45" Name="in" />
+      <NameCon UId="48" Name="in4" />
     </Wire>
     <Wire UId="71">
-      <IdentCon UId="32" />
+      <IdentCon UId="31" />
       <NameCon UId="45" Name="operand" />
     </Wire>
     <Wire UId="72">
       <NameCon UId="45" Name="out" />
-      <NameCon UId="46" Name="in5" />
+      <NameCon UId="46" Name="in" />
     </Wire>
     <Wire UId="73">
-      <NameCon UId="46" Name="out" />
-      <NameCon UId="47" Name="in" />
+      <IdentCon UId="32" />
+      <NameCon UId="46" Name="operand" />
     </Wire>
     <Wire UId="74">
+      <NameCon UId="46" Name="out" />
+      <NameCon UId="48" Name="in5" />
+    </Wire>
+    <Wire UId="75">
       <IdentCon UId="33" />
       <NameCon UId="47" Name="operand" />
+    </Wire>
+    <Wire UId="76">
+      <NameCon UId="47" Name="out" />
+      <NameCon UId="48" Name="in6" />
+    </Wire>
+    <Wire UId="77">
+      <NameCon UId="48" Name="out" />
+      <NameCon UId="49" Name="in" />
+    </Wire>
+    <Wire UId="78">
+      <IdentCon UId="34" />
+      <NameCon UId="49" Name="operand" />
     </Wire>
   </Wires>
 </FlgNet></NetworkSource>
@@ -3569,72 +3584,71 @@
     </Access>
     <Access Scope="GlobalVariable" UId="30">
       <Symbol>
+        <Component Name="Tag_2" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="31">
+      <Symbol>
         <Component Name="DB10_ExtConveyors" />
         <Component Name="Out_ConvPos2" />
       </Symbol>
     </Access>
-    <Part Name="Contact" UId="31" />
     <Part Name="Contact" UId="32" />
     <Part Name="Contact" UId="33" />
     <Part Name="Contact" UId="34" />
-    <Part Name="Contact" UId="35">
-      <Negated Name="operand" />
-    </Part>
+    <Part Name="Contact" UId="35" />
     <Part Name="Contact" UId="36">
       <Negated Name="operand" />
     </Part>
     <Part Name="Contact" UId="37">
       <Negated Name="operand" />
     </Part>
-    <Part Name="Contact" UId="38" />
-    <Part Name="Contact" UId="39" />
-    <Part Name="O" UId="40">
-      <TemplateValue Name="Card" Type="Cardinality">4</TemplateValue>
+    <Part Name="Contact" UId="38">
+      <Negated Name="operand" />
     </Part>
-    <Part Name="Coil" UId="41" />
+    <Part Name="Contact" UId="39" />
+    <Part Name="Contact" UId="40" />
+    <Part Name="Contact" UId="41" />
+    <Part Name="O" UId="42">
+      <TemplateValue Name="Card" Type="Cardinality">5</TemplateValue>
+    </Part>
+    <Part Name="Coil" UId="43" />
   </Parts>
   <Wires>
-    <Wire UId="42">
-      <Powerrail />
-      <NameCon UId="31" Name="in" />
-      <NameCon UId="34" Name="in" />
-      <NameCon UId="38" Name="in" />
-    </Wire>
-    <Wire UId="43">
-      <IdentCon UId="21" />
-      <NameCon UId="31" Name="operand" />
-    </Wire>
     <Wire UId="44">
-      <NameCon UId="31" Name="out" />
+      <Powerrail />
       <NameCon UId="32" Name="in" />
-      <NameCon UId="33" Name="in" />
+      <NameCon UId="35" Name="in" />
+      <NameCon UId="39" Name="in" />
+      <NameCon UId="41" Name="in" />
     </Wire>
     <Wire UId="45">
-      <IdentCon UId="22" />
+      <IdentCon UId="21" />
       <NameCon UId="32" Name="operand" />
     </Wire>
     <Wire UId="46">
       <NameCon UId="32" Name="out" />
-      <NameCon UId="40" Name="in1" />
+      <NameCon UId="33" Name="in" />
+      <NameCon UId="34" Name="in" />
     </Wire>
     <Wire UId="47">
-      <IdentCon UId="23" />
+      <IdentCon UId="22" />
       <NameCon UId="33" Name="operand" />
     </Wire>
     <Wire UId="48">
       <NameCon UId="33" Name="out" />
-      <NameCon UId="40" Name="in2" />
+      <NameCon UId="42" Name="in1" />
     </Wire>
     <Wire UId="49">
-      <IdentCon UId="24" />
+      <IdentCon UId="23" />
       <NameCon UId="34" Name="operand" />
     </Wire>
     <Wire UId="50">
       <NameCon UId="34" Name="out" />
-      <NameCon UId="35" Name="in" />
+      <NameCon UId="42" Name="in2" />
     </Wire>
     <Wire UId="51">
-      <IdentCon UId="25" />
+      <IdentCon UId="24" />
       <NameCon UId="35" Name="operand" />
     </Wire>
     <Wire UId="52">
@@ -3642,7 +3656,7 @@
       <NameCon UId="36" Name="in" />
     </Wire>
     <Wire UId="53">
-      <IdentCon UId="26" />
+      <IdentCon UId="25" />
       <NameCon UId="36" Name="operand" />
     </Wire>
     <Wire UId="54">
@@ -3650,36 +3664,52 @@
       <NameCon UId="37" Name="in" />
     </Wire>
     <Wire UId="55">
-      <IdentCon UId="27" />
+      <IdentCon UId="26" />
       <NameCon UId="37" Name="operand" />
     </Wire>
     <Wire UId="56">
       <NameCon UId="37" Name="out" />
-      <NameCon UId="40" Name="in3" />
+      <NameCon UId="38" Name="in" />
     </Wire>
     <Wire UId="57">
-      <IdentCon UId="28" />
+      <IdentCon UId="27" />
       <NameCon UId="38" Name="operand" />
     </Wire>
     <Wire UId="58">
       <NameCon UId="38" Name="out" />
-      <NameCon UId="39" Name="in" />
+      <NameCon UId="42" Name="in3" />
     </Wire>
     <Wire UId="59">
-      <IdentCon UId="29" />
+      <IdentCon UId="28" />
       <NameCon UId="39" Name="operand" />
     </Wire>
     <Wire UId="60">
       <NameCon UId="39" Name="out" />
-      <NameCon UId="40" Name="in4" />
+      <NameCon UId="40" Name="in" />
     </Wire>
     <Wire UId="61">
-      <NameCon UId="40" Name="out" />
-      <NameCon UId="41" Name="in" />
+      <IdentCon UId="29" />
+      <NameCon UId="40" Name="operand" />
     </Wire>
     <Wire UId="62">
+      <NameCon UId="40" Name="out" />
+      <NameCon UId="42" Name="in4" />
+    </Wire>
+    <Wire UId="63">
       <IdentCon UId="30" />
       <NameCon UId="41" Name="operand" />
+    </Wire>
+    <Wire UId="64">
+      <NameCon UId="41" Name="out" />
+      <NameCon UId="42" Name="in5" />
+    </Wire>
+    <Wire UId="65">
+      <NameCon UId="42" Name="out" />
+      <NameCon UId="43" Name="in" />
+    </Wire>
+    <Wire UId="66">
+      <IdentCon UId="31" />
+      <NameCon UId="43" Name="operand" />
     </Wire>
   </Wires>
 </FlgNet></NetworkSource>
@@ -3721,6 +3751,366 @@
         </ObjectList>
       </SW.Blocks.CompileUnit>
       <SW.Blocks.CompileUnit ID="89" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="Botão_iniciar_primeiro_tapete" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="Tag_2" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="SCoil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="8A" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="8B" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="8C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="8D" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="8E" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>liga motor do primeiro tapete através do botão exterior</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="8F" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="90" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="E4.3" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="Tag_3" />
+      </Symbol>
+    </Access>
+    <Access Scope="TypedConstant" UId="23">
+      <Constant>
+        <ConstantValue>T#1m</ConstantValue>
+      </Constant>
+    </Access>
+    <Access Scope="GlobalVariable" UId="24">
+      <Symbol>
+        <Component Name="Tag_2" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="25" />
+    <Part Name="Contact" UId="26" />
+    <Part Name="TON" Version="1.0" UId="27">
+      <Instance Scope="GlobalVariable" UId="28">
+        <Component Name="IEC_Timer_0_DB" />
+      </Instance>
+      <TemplateValue Name="time_type" Type="Type">Time</TemplateValue>
+    </Part>
+    <Part Name="O" UId="29">
+      <TemplateValue Name="Card" Type="Cardinality">2</TemplateValue>
+    </Part>
+    <Part Name="RCoil" UId="30" />
+  </Parts>
+  <Wires>
+    <Wire UId="32">
+      <Powerrail />
+      <NameCon UId="25" Name="in" />
+      <NameCon UId="26" Name="in" />
+    </Wire>
+    <Wire UId="33">
+      <IdentCon UId="21" />
+      <NameCon UId="25" Name="operand" />
+    </Wire>
+    <Wire UId="34">
+      <NameCon UId="25" Name="out" />
+      <NameCon UId="29" Name="in1" />
+    </Wire>
+    <Wire UId="35">
+      <IdentCon UId="22" />
+      <NameCon UId="26" Name="operand" />
+    </Wire>
+    <Wire UId="36">
+      <NameCon UId="26" Name="out" />
+      <NameCon UId="27" Name="IN" />
+    </Wire>
+    <Wire UId="37">
+      <IdentCon UId="23" />
+      <NameCon UId="27" Name="PT" />
+    </Wire>
+    <Wire UId="38">
+      <NameCon UId="27" Name="Q" />
+      <NameCon UId="29" Name="in2" />
+    </Wire>
+    <Wire UId="39">
+      <NameCon UId="27" Name="ET" />
+      <OpenCon UId="31" />
+    </Wire>
+    <Wire UId="40">
+      <NameCon UId="29" Name="out" />
+      <NameCon UId="30" Name="in" />
+    </Wire>
+    <Wire UId="41">
+      <IdentCon UId="24" />
+      <NameCon UId="30" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="91" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="92" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="93" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="94" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="95" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>Pára motor com sinal da célula correspondente ou por tempo</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="96" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="97" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="Botão_iniciar_primeiro_tapete" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="Tag_3" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="23" />
+    <Part Name="SCoil" UId="24" />
+  </Parts>
+  <Wires>
+    <Wire UId="25">
+      <Powerrail />
+      <NameCon UId="23" Name="in" />
+    </Wire>
+    <Wire UId="26">
+      <IdentCon UId="21" />
+      <NameCon UId="23" Name="operand" />
+    </Wire>
+    <Wire UId="27">
+      <NameCon UId="23" Name="out" />
+      <NameCon UId="24" Name="in" />
+    </Wire>
+    <Wire UId="28">
+      <IdentCon UId="22" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="98" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="99" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="9A" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="9B" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="9C" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>inicia contagem após pressionar botão de arranque do primeiro tapete</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="9D" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="9E" CompositionName="CompileUnits">
+        <AttributeList>
+          <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
+  <Parts>
+    <Access Scope="GlobalVariable" UId="21">
+      <Symbol>
+        <Component Name="E4.3" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="22">
+      <Symbol>
+        <Component Name="IEC_Timer_0_DB" />
+        <Component Name="Q" />
+      </Symbol>
+    </Access>
+    <Access Scope="GlobalVariable" UId="23">
+      <Symbol>
+        <Component Name="Tag_3" />
+      </Symbol>
+    </Access>
+    <Part Name="Contact" UId="24" />
+    <Part Name="Contact" UId="25" />
+    <Part Name="O" UId="26">
+      <TemplateValue Name="Card" Type="Cardinality">2</TemplateValue>
+    </Part>
+    <Part Name="RCoil" UId="27" />
+  </Parts>
+  <Wires>
+    <Wire UId="28">
+      <Powerrail />
+      <NameCon UId="24" Name="in" />
+      <NameCon UId="25" Name="in" />
+    </Wire>
+    <Wire UId="29">
+      <IdentCon UId="21" />
+      <NameCon UId="24" Name="operand" />
+    </Wire>
+    <Wire UId="30">
+      <NameCon UId="24" Name="out" />
+      <NameCon UId="26" Name="in1" />
+    </Wire>
+    <Wire UId="31">
+      <IdentCon UId="22" />
+      <NameCon UId="25" Name="operand" />
+    </Wire>
+    <Wire UId="32">
+      <NameCon UId="25" Name="out" />
+      <NameCon UId="26" Name="in2" />
+    </Wire>
+    <Wire UId="33">
+      <NameCon UId="26" Name="out" />
+      <NameCon UId="27" Name="in" />
+    </Wire>
+    <Wire UId="34">
+      <IdentCon UId="23" />
+      <NameCon UId="27" Name="operand" />
+    </Wire>
+  </Wires>
+</FlgNet></NetworkSource>
+          <ProgrammingLanguage>LAD</ProgrammingLanguage>
+        </AttributeList>
+        <ObjectList>
+          <MultilingualText ID="9F" CompositionName="Comment">
+            <ObjectList>
+              <MultilingualTextItem ID="A0" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="A1" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+          <MultilingualText ID="A2" CompositionName="Title">
+            <ObjectList>
+              <MultilingualTextItem ID="A3" CompositionName="Items">
+                <AttributeList>
+                  <Culture>en-US</Culture>
+                  <Text>reset à contagem anterior pela célula</Text>
+                </AttributeList>
+              </MultilingualTextItem>
+              <MultilingualTextItem ID="A4" CompositionName="Items">
+                <AttributeList>
+                  <Culture>it-IT</Culture>
+                  <Text />
+                </AttributeList>
+              </MultilingualTextItem>
+            </ObjectList>
+          </MultilingualText>
+        </ObjectList>
+      </SW.Blocks.CompileUnit>
+      <SW.Blocks.CompileUnit ID="A5" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -3891,15 +4281,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="8A" CompositionName="Comment">
+          <MultilingualText ID="A6" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="8B" CompositionName="Items">
+              <MultilingualTextItem ID="A7" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="8C" CompositionName="Items">
+              <MultilingualTextItem ID="A8" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -3907,15 +4297,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="8D" CompositionName="Title">
+          <MultilingualText ID="A9" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="8E" CompositionName="Items">
+              <MultilingualTextItem ID="AA" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="8F" CompositionName="Items">
+              <MultilingualTextItem ID="AB" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos3 motor</Text>
@@ -3925,7 +4315,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="90" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="AC" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4096,15 +4486,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="91" CompositionName="Comment">
+          <MultilingualText ID="AD" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="92" CompositionName="Items">
+              <MultilingualTextItem ID="AE" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="93" CompositionName="Items">
+              <MultilingualTextItem ID="AF" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4112,15 +4502,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="94" CompositionName="Title">
+          <MultilingualText ID="B0" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="95" CompositionName="Items">
+              <MultilingualTextItem ID="B1" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="96" CompositionName="Items">
+              <MultilingualTextItem ID="B2" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos4 motor</Text>
@@ -4130,7 +4520,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="97" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="B3" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4300,15 +4690,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="98" CompositionName="Comment">
+          <MultilingualText ID="B4" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="99" CompositionName="Items">
+              <MultilingualTextItem ID="B5" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="9A" CompositionName="Items">
+              <MultilingualTextItem ID="B6" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4316,15 +4706,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="9B" CompositionName="Title">
+          <MultilingualText ID="B7" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="9C" CompositionName="Items">
+              <MultilingualTextItem ID="B8" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="9D" CompositionName="Items">
+              <MultilingualTextItem ID="B9" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos5 motor</Text>
@@ -4334,7 +4724,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="9E" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="BA" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4496,15 +4886,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="9F" CompositionName="Comment">
+          <MultilingualText ID="BB" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="A0" CompositionName="Items">
+              <MultilingualTextItem ID="BC" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="A1" CompositionName="Items">
+              <MultilingualTextItem ID="BD" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4512,15 +4902,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="A2" CompositionName="Title">
+          <MultilingualText ID="BE" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="A3" CompositionName="Items">
+              <MultilingualTextItem ID="BF" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="A4" CompositionName="Items">
+              <MultilingualTextItem ID="C0" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Pallet ready in infeed signal (Std signal)</Text>
@@ -4530,7 +4920,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="A5" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="C1" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4699,15 +5089,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="A6" CompositionName="Comment">
+          <MultilingualText ID="C2" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="A7" CompositionName="Items">
+              <MultilingualTextItem ID="C3" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="A8" CompositionName="Items">
+              <MultilingualTextItem ID="C4" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4715,15 +5105,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="A9" CompositionName="Title">
+          <MultilingualText ID="C5" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="AA" CompositionName="Items">
+              <MultilingualTextItem ID="C6" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="AB" CompositionName="Items">
+              <MultilingualTextItem ID="C7" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Memory to exclude wrapping in pos 1</Text>
@@ -4733,21 +5123,21 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="AC" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="C8" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="AD" CompositionName="Comment">
+          <MultilingualText ID="C9" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="AE" CompositionName="Items">
+              <MultilingualTextItem ID="CA" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="AF" CompositionName="Items">
+              <MultilingualTextItem ID="CB" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4755,15 +5145,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="B0" CompositionName="Title">
+          <MultilingualText ID="CC" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="B1" CompositionName="Items">
+              <MultilingualTextItem ID="CD" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="B2" CompositionName="Items">
+              <MultilingualTextItem ID="CE" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>&gt;&gt;&gt;&gt;&gt;&gt;&gt; OUTFEED CONVEYOR &lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;</Text>
@@ -4773,7 +5163,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="B3" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="CF" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4841,15 +5231,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="B4" CompositionName="Comment">
+          <MultilingualText ID="D0" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="B5" CompositionName="Items">
+              <MultilingualTextItem ID="D1" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="B6" CompositionName="Items">
+              <MultilingualTextItem ID="D2" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4857,15 +5247,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="B7" CompositionName="Title">
+          <MultilingualText ID="D3" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="B8" CompositionName="Items">
+              <MultilingualTextItem ID="D4" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="B9" CompositionName="Items">
+              <MultilingualTextItem ID="D5" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Timeout for conveyor pos 06</Text>
@@ -4875,7 +5265,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="BA" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="D6" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -4943,15 +5333,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="BB" CompositionName="Comment">
+          <MultilingualText ID="D7" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="BC" CompositionName="Items">
+              <MultilingualTextItem ID="D8" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="BD" CompositionName="Items">
+              <MultilingualTextItem ID="D9" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -4959,15 +5349,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="BE" CompositionName="Title">
+          <MultilingualText ID="DA" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="BF" CompositionName="Items">
+              <MultilingualTextItem ID="DB" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="C0" CompositionName="Items">
+              <MultilingualTextItem ID="DC" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Timeout for conveyor pos 07</Text>
@@ -4977,7 +5367,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="C1" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="DD" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5045,15 +5435,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="C2" CompositionName="Comment">
+          <MultilingualText ID="DE" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="C3" CompositionName="Items">
+              <MultilingualTextItem ID="DF" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="C4" CompositionName="Items">
+              <MultilingualTextItem ID="E0" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5061,15 +5451,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="C5" CompositionName="Title">
+          <MultilingualText ID="E1" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="C6" CompositionName="Items">
+              <MultilingualTextItem ID="E2" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="C7" CompositionName="Items">
+              <MultilingualTextItem ID="E3" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Timeout for conveyor pos 08</Text>
@@ -5079,7 +5469,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="C8" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="E4" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5200,15 +5590,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="C9" CompositionName="Comment">
+          <MultilingualText ID="E5" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="CA" CompositionName="Items">
+              <MultilingualTextItem ID="E6" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="CB" CompositionName="Items">
+              <MultilingualTextItem ID="E7" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5216,15 +5606,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="CC" CompositionName="Title">
+          <MultilingualText ID="E8" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="CD" CompositionName="Items">
+              <MultilingualTextItem ID="E9" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="CE" CompositionName="Items">
+              <MultilingualTextItem ID="EA" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Time for pallet unload with forklift</Text>
@@ -5234,7 +5624,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="CF" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="EB" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5375,15 +5765,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="D0" CompositionName="Comment">
+          <MultilingualText ID="EC" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="D1" CompositionName="Items">
+              <MultilingualTextItem ID="ED" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="D2" CompositionName="Items">
+              <MultilingualTextItem ID="EE" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5391,15 +5781,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="D3" CompositionName="Title">
+          <MultilingualText ID="EF" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="D4" CompositionName="Items">
+              <MultilingualTextItem ID="F0" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="D5" CompositionName="Items">
+              <MultilingualTextItem ID="F1" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Transit memory pos6->pos7</Text>
@@ -5409,7 +5799,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="D6" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="F2" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5566,15 +5956,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="D7" CompositionName="Comment">
+          <MultilingualText ID="F3" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="D8" CompositionName="Items">
+              <MultilingualTextItem ID="F4" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="D9" CompositionName="Items">
+              <MultilingualTextItem ID="F5" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5582,15 +5972,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="DA" CompositionName="Title">
+          <MultilingualText ID="F6" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="DB" CompositionName="Items">
+              <MultilingualTextItem ID="F7" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="DC" CompositionName="Items">
+              <MultilingualTextItem ID="F8" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Transit memory pos7->pos8</Text>
@@ -5600,7 +5990,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="DD" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="F9" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5758,15 +6148,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="DE" CompositionName="Comment">
+          <MultilingualText ID="FA" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="DF" CompositionName="Items">
+              <MultilingualTextItem ID="FB" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="E0" CompositionName="Items">
+              <MultilingualTextItem ID="FC" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5774,15 +6164,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="E1" CompositionName="Title">
+          <MultilingualText ID="FD" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="E2" CompositionName="Items">
+              <MultilingualTextItem ID="FE" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="E3" CompositionName="Items">
+              <MultilingualTextItem ID="FF" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Outfeed conveyor pos.8 unload</Text>
@@ -5792,7 +6182,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="E4" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="100" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -5941,15 +6331,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="E5" CompositionName="Comment">
+          <MultilingualText ID="101" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="E6" CompositionName="Items">
+              <MultilingualTextItem ID="102" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="E7" CompositionName="Items">
+              <MultilingualTextItem ID="103" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -5957,15 +6347,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="E8" CompositionName="Title">
+          <MultilingualText ID="104" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="E9" CompositionName="Items">
+              <MultilingualTextItem ID="105" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="EA" CompositionName="Items">
+              <MultilingualTextItem ID="106" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Ready to receive pallet from outfeed signal (Signal for Technoplat)</Text>
@@ -5975,7 +6365,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="EB" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="107" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -6153,15 +6543,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="EC" CompositionName="Comment">
+          <MultilingualText ID="108" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="ED" CompositionName="Items">
+              <MultilingualTextItem ID="109" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="EE" CompositionName="Items">
+              <MultilingualTextItem ID="10A" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -6169,15 +6559,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="EF" CompositionName="Title">
+          <MultilingualText ID="10B" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="F0" CompositionName="Items">
+              <MultilingualTextItem ID="10C" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="F1" CompositionName="Items">
+              <MultilingualTextItem ID="10D" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos6 motor</Text>
@@ -6187,7 +6577,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="F2" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="10E" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -6358,15 +6748,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="F3" CompositionName="Comment">
+          <MultilingualText ID="10F" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="F4" CompositionName="Items">
+              <MultilingualTextItem ID="110" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="F5" CompositionName="Items">
+              <MultilingualTextItem ID="111" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -6374,15 +6764,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="F6" CompositionName="Title">
+          <MultilingualText ID="112" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="F7" CompositionName="Items">
+              <MultilingualTextItem ID="113" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="F8" CompositionName="Items">
+              <MultilingualTextItem ID="114" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos7 motor</Text>
@@ -6392,7 +6782,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="F9" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="115" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -6632,15 +7022,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="FA" CompositionName="Comment">
+          <MultilingualText ID="116" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="FB" CompositionName="Items">
+              <MultilingualTextItem ID="117" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="FC" CompositionName="Items">
+              <MultilingualTextItem ID="118" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -6648,15 +7038,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="FD" CompositionName="Title">
+          <MultilingualText ID="119" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="FE" CompositionName="Items">
+              <MultilingualTextItem ID="11A" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="FF" CompositionName="Items">
+              <MultilingualTextItem ID="11B" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Conveyor pos8 motor</Text>
@@ -6666,7 +7056,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="100" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="11C" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -6789,15 +7179,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="101" CompositionName="Comment">
+          <MultilingualText ID="11D" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="102" CompositionName="Items">
+              <MultilingualTextItem ID="11E" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="103" CompositionName="Items">
+              <MultilingualTextItem ID="11F" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -6805,15 +7195,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="104" CompositionName="Title">
+          <MultilingualText ID="120" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="105" CompositionName="Items">
+              <MultilingualTextItem ID="121" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="106" CompositionName="Items">
+              <MultilingualTextItem ID="122" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>Pallet ready in outfeed signal</Text>
@@ -6823,7 +7213,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="107" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="123" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -6944,15 +7334,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="108" CompositionName="Comment">
+          <MultilingualText ID="124" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="109" CompositionName="Items">
+              <MultilingualTextItem ID="125" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="10A" CompositionName="Items">
+              <MultilingualTextItem ID="126" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>tutto fermo, senza transito 4->5, a seguito della richiesta E118</Text>
@@ -6960,15 +7350,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="10B" CompositionName="Title">
+          <MultilingualText ID="127" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="10C" CompositionName="Items">
+              <MultilingualTextItem ID="128" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="10D" CompositionName="Items">
+              <MultilingualTextItem ID="129" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>SEGNALE PRONTO PER CHIUSURA PORTA TAGLIAFUOCO</Text>
@@ -6978,7 +7368,7 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="10E" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="12A" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource><FlgNet xmlns="http://www.siemens.com/automation/Openness/SW/NetworkSource/FlgNet/v4">
   <Parts>
@@ -7017,15 +7407,15 @@
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="10F" CompositionName="Comment">
+          <MultilingualText ID="12B" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="110" CompositionName="Items">
+              <MultilingualTextItem ID="12C" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="111" CompositionName="Items">
+              <MultilingualTextItem ID="12D" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -7033,15 +7423,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="112" CompositionName="Title">
+          <MultilingualText ID="12E" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="113" CompositionName="Items">
+              <MultilingualTextItem ID="12F" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="114" CompositionName="Items">
+              <MultilingualTextItem ID="130" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text>LedBypass</Text>
@@ -7051,21 +7441,21 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <SW.Blocks.CompileUnit ID="115" CompositionName="CompileUnits">
+      <SW.Blocks.CompileUnit ID="131" CompositionName="CompileUnits">
         <AttributeList>
           <NetworkSource />
           <ProgrammingLanguage>LAD</ProgrammingLanguage>
         </AttributeList>
         <ObjectList>
-          <MultilingualText ID="116" CompositionName="Comment">
+          <MultilingualText ID="132" CompositionName="Comment">
             <ObjectList>
-              <MultilingualTextItem ID="117" CompositionName="Items">
+              <MultilingualTextItem ID="133" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="118" CompositionName="Items">
+              <MultilingualTextItem ID="134" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -7073,15 +7463,15 @@
               </MultilingualTextItem>
             </ObjectList>
           </MultilingualText>
-          <MultilingualText ID="119" CompositionName="Title">
+          <MultilingualText ID="135" CompositionName="Title">
             <ObjectList>
-              <MultilingualTextItem ID="11A" CompositionName="Items">
+              <MultilingualTextItem ID="136" CompositionName="Items">
                 <AttributeList>
                   <Culture>en-US</Culture>
                   <Text />
                 </AttributeList>
               </MultilingualTextItem>
-              <MultilingualTextItem ID="11B" CompositionName="Items">
+              <MultilingualTextItem ID="137" CompositionName="Items">
                 <AttributeList>
                   <Culture>it-IT</Culture>
                   <Text />
@@ -7091,15 +7481,15 @@
           </MultilingualText>
         </ObjectList>
       </SW.Blocks.CompileUnit>
-      <MultilingualText ID="11C" CompositionName="Title">
+      <MultilingualText ID="138" CompositionName="Title">
         <ObjectList>
-          <MultilingualTextItem ID="11D" CompositionName="Items">
+          <MultilingualTextItem ID="139" CompositionName="Items">
             <AttributeList>
               <Culture>en-US</Culture>
               <Text />
             </AttributeList>
           </MultilingualTextItem>
-          <MultilingualTextItem ID="11E" CompositionName="Items">
+          <MultilingualTextItem ID="13A" CompositionName="Items">
             <AttributeList>
               <Culture>it-IT</Culture>
               <Text>Conveyor_5_IN_3_OUT</Text>

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Main.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/Main.xml
@@ -2,7 +2,7 @@
 <Document>
   <Engineering version="V16" />
   <DocumentInfo>
-    <Created>2022-11-24T15:20:38.5982156Z</Created>
+    <Created>2022-12-12T11:32:01.1043843Z</Created>
     <ExportSetting>WithDefaults</ExportSetting>
     <InstalledProducts>
       <Product>
@@ -5607,7 +5607,7 @@ FC86 = SPECIAL</Text>
     </Access>
     <Access Scope="GlobalVariable" UId="23">
       <Symbol>
-        <Component Name="E3.2" />
+        <Component Name="E4.3" />
       </Symbol>
     </Access>
     <Access Scope="GlobalVariable" UId="24">

--- a/Pentaplast_centrador_paletes_V16/S71200/Program blocks/System blocks/Program resources/IEC_Timer_0_DB.xml
+++ b/Pentaplast_centrador_paletes_V16/S71200/Program blocks/System blocks/Program resources/IEC_Timer_0_DB.xml
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document>
+  <Engineering version="V16" />
+  <DocumentInfo>
+    <Created>2022-12-12T13:38:58.2705134Z</Created>
+    <ExportSetting>WithDefaults</ExportSetting>
+    <InstalledProducts>
+      <Product>
+        <DisplayName>Totally Integrated Automation Portal</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>TIA Portal Version Control Interface</DisplayName>
+        <DisplayVersion>V16 Update 2</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>TIA Portal Openness</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>SINAMICS Startdrive Advanced</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G130, G150, S120, S150, SINAMICS MV, S210</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </OptionPackage>
+      <OptionPackage>
+        <DisplayName>SINAMICS Startdrive G110M, G120, G120C, G120D, G120P, G115D</DisplayName>
+        <DisplayVersion>V16 Update 5</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>STEP 7 Professional</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+      <OptionPackage>
+        <DisplayName>STEP 7 Safety</DisplayName>
+        <DisplayVersion>V16</DisplayVersion>
+      </OptionPackage>
+      <Product>
+        <DisplayName>WinCC Advanced</DisplayName>
+        <DisplayVersion>V16 Update 6</DisplayVersion>
+      </Product>
+    </InstalledProducts>
+  </DocumentInfo>
+  <SW.Blocks.InstanceDB ID="0">
+    <AttributeList>
+      <AutoNumber>true</AutoNumber>
+      <InstanceOfName>IEC_TIMER</InstanceOfName>
+      <Interface><Sections xmlns="http://www.siemens.com/automation/Openness/SW/Interface/v4">
+  <Section Name="Static">
+    <Member Name="PT" Datatype="Time" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute></AttributeList></Member>
+    <Member Name="ET" Datatype="Time" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">false</BooleanAttribute><BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute></AttributeList></Member>
+    <Member Name="IN" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute></AttributeList></Member>
+    <Member Name="Q" Datatype="Bool" Remanence="NonRetain" Accessibility="Public"><AttributeList><BooleanAttribute Name="ExternalAccessible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalVisible" SystemDefined="true">true</BooleanAttribute><BooleanAttribute Name="ExternalWritable" SystemDefined="true">false</BooleanAttribute><BooleanAttribute Name="SetPoint" SystemDefined="true">false</BooleanAttribute></AttributeList></Member>
+  </Section>
+</Sections></Interface>
+      <MemoryLayout>Optimized</MemoryLayout>
+      <Name>IEC_Timer_0_DB</Name>
+      <Number>15</Number>
+      <OfSystemLibElement>IEC_TIMER</OfSystemLibElement>
+      <OfSystemLibVersion>1.0</OfSystemLibVersion>
+      <ProgrammingLanguage>DB</ProgrammingLanguage>
+    </AttributeList>
+    <ObjectList>
+      <MultilingualText ID="1" CompositionName="Comment">
+        <ObjectList>
+          <MultilingualTextItem ID="2" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="3" CompositionName="Items">
+            <AttributeList>
+              <Culture>it-IT</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+      <MultilingualText ID="4" CompositionName="Title">
+        <ObjectList>
+          <MultilingualTextItem ID="5" CompositionName="Items">
+            <AttributeList>
+              <Culture>en-US</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+          <MultilingualTextItem ID="6" CompositionName="Items">
+            <AttributeList>
+              <Culture>it-IT</Culture>
+              <Text />
+            </AttributeList>
+          </MultilingualTextItem>
+        </ObjectList>
+      </MultilingualText>
+    </ObjectList>
+  </SW.Blocks.InstanceDB>
+</Document>


### PR DESCRIPTION
Correção das tags de input e output do bloco do centrador. Sensores de centrador aberto: basta que um esteja ativo para permitir arranque do tapete Ao ativar botão exterior dá início ao arranque do tapete, caso o centrador esteja aberto. Pára ao fim de 2 minutos caso não haja palete.